### PR TITLE
Changing league/oauth2-client version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,18 @@
+language: php
+
+php:
+  - 5.6
+  - 7.0
+  - 7.1
+  - hhvm
+
+matrix:
+  allow_failures:
+    - php: hhvm
+  fast_finish: true
+
+install:
+  - travis_retry composer update --prefer-dist --no-interaction --prefer-stable --no-suggest
+
+script:
+  - vendor/bin/phpunit

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
   ],
   "require": {
     "php": ">=5.6",
-    "league/oauth2-client": "1.2.0"
+    "league/oauth2-client": "^2.0"
   },
   "require-dev": {
     "mockery/mockery": "0.9.4",

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
   ],
   "require": {
     "php": ">=5.6",
-    "league/oauth2-client": "^2.0"
+    "league/oauth2-client": "~1.0|~2.0"
   },
   "require-dev": {
     "mockery/mockery": "0.9.4",


### PR DESCRIPTION
Hi Andrew, 

Would you consider changing league/oauth2-client version from the current locked version 1.2.0 to "^2.0".
 
All "official" provider libraries:

- league/oauth2-facebook	
- league/oauth2-github	
- league/oauth2-google	
- league/oauth2-instagram	
- league/oauth2-linkedin

 are using league/oauth2-client version "^2.0" as a requirement witch generates conflict with version 1.2.0.  

This conflict prevents installation of linkshare/oauth2-linkshare along with some other package based on league/oauth2-client.

I ran the tests with the updated league/oauth2-client version and did not encounter any problems.

Thanks, 
Plamen

  